### PR TITLE
Mutiple cookbook and databag paths

### DIFF
--- a/lib/chefdepartie/cache.rb
+++ b/lib/chefdepartie/cache.rb
@@ -62,8 +62,8 @@ module Chefdepartie
         path.gsub(/.*data_bags/, 'data').gsub('.json', '')
       when /\/roles\//
         File.join('roles', path.gsub(/.*roles\//, '').gsub('/', '--').gsub('.rb', ''))
-      when /cookbooks\//
-        path.gsub(/.*cookbooks/, 'cookbooks')
+      when /cookbooks[^\/]*\//
+        path.gsub(/.*cookbooks([^\/]*)/, 'cookbooks\1')
       end
     end
   end

--- a/lib/chefdepartie/cache.rb
+++ b/lib/chefdepartie/cache.rb
@@ -58,12 +58,12 @@ module Chefdepartie
 
     def to_key(path)
       case path
-      when /\/data_bags\//
-        path.gsub(/.*data_bags/, 'data').gsub('.json', '')
+      when /data_bags[^\/]*\//
+        path.gsub(/.*data_bags([^\/]*)/, 'data').gsub('.json', '')
       when /\/roles\//
         File.join('roles', path.gsub(/.*roles\//, '').gsub('/', '--').gsub('.rb', ''))
       when /cookbooks[^\/]*\//
-        path.gsub(/.*cookbooks([^\/]*)/, 'cookbooks\1')
+        path.gsub(/.*cookbooks([^\/]*)/, 'cookbooks')
       end
     end
   end

--- a/lib/chefdepartie/cookbook.rb
+++ b/lib/chefdepartie/cookbook.rb
@@ -10,13 +10,13 @@ module Chefdepartie
   # Handle finding and uploading cookbooks
   module Cookbooks
     def self.upload_all
-      Dir.chdir(Chef::Config[:chef_repo_path].first) do
+      Dir.chdir(Chef::Config[:chef_repo_path]) do
         puts 'Uploading librarian cookbooks'
         upload_cheffile
 
         puts 'Uploading site cookbooks'
         books = []
-        cookbook_path = Chef::Config[:cookbook_path]
+        cookbook_path = [Chef::Config[:cookbook_path]].flatten
         cookbook_path.each do |p|
           p.chomp!("/")
           books << Dir["#{p.gsub(/^..\//, '')}/*"]

--- a/lib/chefdepartie/cookbook.rb
+++ b/lib/chefdepartie/cookbook.rb
@@ -10,14 +10,18 @@ module Chefdepartie
   # Handle finding and uploading cookbooks
   module Cookbooks
     def self.upload_all
-      cookbooks = File.dirname(Chef::Config[:cookbook_path])
-      Dir.chdir(cookbooks) do
+      Dir.chdir(Chef::Config[:chef_repo_path].first) do
         puts 'Uploading librarian cookbooks'
         upload_cheffile
 
         puts 'Uploading site cookbooks'
-        books = Dir['cookbooks/*']
-        upload_site_cookbooks(books)
+        books = []
+        cookbook_path = Chef::Config[:cookbook_path]
+        cookbook_path.each do |p|
+          p.chomp!("/")
+          books << Dir["#{p.gsub(/^..\//, '')}/*"]
+        end
+        upload_site_cookbooks(books.flatten)
       end
     end
 

--- a/lib/chefdepartie/databag.rb
+++ b/lib/chefdepartie/databag.rb
@@ -43,9 +43,13 @@ module Chefdepartie
   module Databags
     def self.upload_all
       puts 'Uploading databags'
-      cookbooks = File.dirname(Chef::Config[:cookbook_path])
-      bags = Dir[File.join(cookbooks, 'data_bags', '/*')]
-      upload_all_data_bags(bags)
+      bags = []
+      data_bag_path = [Chef::Config[:data_bag_path]].flatten
+        data_bag_path.each do |path|
+          bag = Dir[File.join(path, '/*')]
+          bags << bag
+        end
+      upload_all_data_bags(bags.flatten)
     end
 
     private

--- a/lib/chefdepartie/role.rb
+++ b/lib/chefdepartie/role.rb
@@ -5,9 +5,11 @@ module Chefdepartie
   module Roles
     def self.upload_all
       puts 'Uploading roles'
-      cookbooks = File.dirname(Chef::Config[:cookbook_path])
       roles = []
-      Find.find(File.join(cookbooks, 'roles')) { |f| roles << f if f =~ /\.rb$/ && !Cache.cache(f) }
+      role_path = [ Chef::Config[:role_path] ].flatten
+      role_path.each do |role_path|
+        Find.find(role_path) { |f| roles << f if f =~ /\.rb$/ && !Cache.cache(f) }
+      end
       upload_site_roles(roles)
     end
 


### PR DESCRIPTION
- allows for additional cookbook paths using `Chef::Config[:cookbook_path]` array setting
- updated databags library to leverage the `Chef::Config[:data_bag_path]` array setting to allow for mutiple databag paths 
