### PR TITLE
Add support for Berkshelf

### DIFF
--- a/chefdepartie.gemspec
+++ b/chefdepartie.gemspec
@@ -16,7 +16,8 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'chef', ['=12.9.38']
   s.add_runtime_dependency 'chef-zero', '~> 4.2', '>= 4.2.2'
   s.add_runtime_dependency 'librarian-chef', '~> 0.0.4'
-  s.add_runtime_dependency 'cityhash', '~> 0.8.1'
+  s.add_runtime_dependency 'berkshelf', '~> 4.3.0'
+  s.add_runtime_dependency 'cityhash', '~> 0.6.0'
   s.add_development_dependency 'rake', ['=10.4.2']
   s.add_development_dependency 'simplecov', ['=0.10.0']
   s.add_development_dependency 'rspec', ['=3.4.0']

--- a/lib/chefdepartie.rb
+++ b/lib/chefdepartie.rb
@@ -7,3 +7,5 @@ require 'chefdepartie/role'
 require 'chefdepartie/cookbook'
 require 'chefdepartie/databag'
 require 'chefdepartie/cache'
+
+Chefdepartie.run(background: true, config: 'config.rb', cache: nil)

--- a/lib/chefdepartie.rb
+++ b/lib/chefdepartie.rb
@@ -7,5 +7,3 @@ require 'chefdepartie/role'
 require 'chefdepartie/cookbook'
 require 'chefdepartie/databag'
 require 'chefdepartie/cache'
-
-Chefdepartie.run(background: true, config: 'config.rb', cache: nil)

--- a/spec/lib/chef_spec.rb
+++ b/spec/lib/chef_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Chefdepartie::Runner do
     it 'can cache uploads' do
       cache = Dir.mktmpdir
       expect{Chefdepartie.run(background: true, config: chef_config, cache: cache)}.to output(/Ready/).to_stdout
-      expect{Chefdepartie.run(background: true, config: chef_config, cache: cache)}.to output("Uploading roles\nUploading databags\nUploading librarian cookbooks\nUploading site cookbooks\nReady\n").to_stdout
+      expect{Chefdepartie.run(background: true, config: chef_config, cache: cache)}.to output("Uploading roles\nUploading databags\nUploading dependency cookbooks\nUploading site cookbooks\nReady\n").to_stdout
     end
   end
 end


### PR DESCRIPTION
This adds preferential support for Berkshelf instead of Librarian for
uploading a chef-repo to a chef-zero server.  If a Berksfile is present,
it will be used, otherwise Librarian is used to upload dependent
cookbooks.  Note that 'berks upload' is not used, as that may upload to
the real chef server, though this is a future optimization to consider.
